### PR TITLE
Enable manual build workflow dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
     branches:
     - main
     - stable
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- allow the Build workflow to be run manually via GitHub's "Run workflow" button

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbf2e4dcc88323859faeed180d27b2