### PR TITLE
Add MSVC compatibility shim for unistd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ project(baresip VERSION 4.1.0)
 
 set(PROJECT_SOVERSION 22) # bump if ABI breaks
 
+# Additional compatibility headers for the MSVC toolchain.
+if(MSVC)
+  set(BARESIP_MSVC_COMPAT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include/msvc_compat")
+  include_directories(BEFORE "${BARESIP_MSVC_COMPAT_DIR}")
+endif()
+
 # Pre-release identifier, comment out on a release
 # Increment for breaking changes (dev2, dev3...)
 #set(PROJECT_VERSION_PRE dev)
@@ -148,6 +154,37 @@ list(REMOVE_ITEM RE_INCLUDE_DIRS "")
 set(RE_INCLUDE_DIR ${RE_INCLUDE_DIRS})
 set(RE_LIBRARY ${RE_LIBRARIES})
 set(RE_FOUND TRUE)
+
+if(MSVC AND DEFINED BARESIP_MSVC_COMPAT_DIR)
+  set(_re_targets)
+
+  foreach(_candidate re libre)
+    if(TARGET ${_candidate})
+      list(APPEND _re_targets ${_candidate})
+    endif()
+  endforeach()
+
+  if(TARGET re::re)
+    get_target_property(_re_alias_target re::re ALIASED_TARGET)
+    if(_re_alias_target)
+      list(APPEND _re_targets ${_re_alias_target})
+    endif()
+    unset(_re_alias_target)
+  endif()
+
+  if(TARGET re-objs)
+    list(APPEND _re_targets re-objs)
+  endif()
+
+  list(REMOVE_DUPLICATES _re_targets)
+
+  foreach(_re_target IN LISTS _re_targets)
+    target_include_directories(${_re_target} BEFORE PRIVATE ${BARESIP_MSVC_COMPAT_DIR})
+  endforeach()
+
+  unset(_re_target)
+  unset(_re_targets)
+endif()
 
 ##############################################################################
 #
@@ -373,7 +410,6 @@ endif()
 if(STATIC)
   add_library(baresip STATIC ${SRCS} ${HEADERS})
   target_link_libraries(baresip PUBLIC ${LINKLIBS} ${MODULES_DETECTED})
-  target_include_directories(baresip PUBLIC include)
 else()
   add_library(baresip SHARED ${SRCS} ${HEADERS})
   target_link_libraries(baresip PRIVATE ${LINKLIBS})
@@ -385,6 +421,13 @@ endif()
 if(MSVC)
   set_target_properties(baresip PROPERTIES OUTPUT_NAME "libbaresip")
 endif()
+
+set(_baresip_public_includes ${CMAKE_CURRENT_SOURCE_DIR}/include)
+if(MSVC)
+  list(APPEND _baresip_public_includes ${BARESIP_MSVC_COMPAT_DIR})
+endif()
+target_include_directories(baresip PUBLIC ${_baresip_public_includes})
+unset(_baresip_public_includes)
 
 set_target_properties(baresip PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/include/msvc_compat/unistd.h
+++ b/include/msvc_compat/unistd.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#ifdef _MSC_VER
+
+#include <BaseTsd.h>
+#include <direct.h>
+#include <io.h>
+#include <process.h>
+#include <stdlib.h>
+#include <windows.h>
+
+#ifndef ssize_t
+typedef SSIZE_T ssize_t;
+#endif
+
+#ifndef pid_t
+typedef int pid_t;
+#endif
+
+#ifndef uid_t
+typedef int uid_t;
+#endif
+
+#ifndef gid_t
+typedef int gid_t;
+#endif
+
+#ifndef F_OK
+#define F_OK 0
+#endif
+#ifndef X_OK
+#define X_OK 1
+#endif
+#ifndef W_OK
+#define W_OK 2
+#endif
+#ifndef R_OK
+#define R_OK 4
+#endif
+
+#ifndef STDIN_FILENO
+#define STDIN_FILENO 0
+#endif
+#ifndef STDOUT_FILENO
+#define STDOUT_FILENO 1
+#endif
+#ifndef STDERR_FILENO
+#define STDERR_FILENO 2
+#endif
+
+#ifndef access
+#define access _access
+#endif
+#ifndef dup2
+#define dup2 _dup2
+#endif
+#ifndef fileno
+#define fileno _fileno
+#endif
+#ifndef getpid
+#define getpid _getpid
+#endif
+#ifndef isatty
+#define isatty _isatty
+#endif
+#ifndef lseek
+#define lseek _lseek
+#endif
+#ifndef read
+#define read _read
+#endif
+#ifndef write
+#define write _write
+#endif
+#ifndef close
+#define close _close
+#endif
+#ifndef unlink
+#define unlink _unlink
+#endif
+
+#ifndef usleep
+static inline int usleep(unsigned int usec)
+{
+    Sleep((usec + 999) / 1000);
+    return 0;
+}
+#endif
+
+#ifndef sleep
+static inline unsigned int sleep(unsigned int seconds)
+{
+    Sleep(seconds * 1000);
+    return 0;
+}
+#endif
+
+#ifndef pipe
+#define pipe _pipe
+#endif
+
+#else
+#include_next <unistd.h>
+#endif
+


### PR DESCRIPTION
## Summary
- add a compatibility implementation of `<unistd.h>` for the MSVC toolchain with the POSIX shims used in the project
- expose the compatibility headers to MSVC builds and the fetched libre dependency so Windows CI no longer requires the missing system header

## Testing
- cmake -S . -B build *(fails: network restrictions prevent cloning libre during configure)*

------
https://chatgpt.com/codex/tasks/task_e_68cc23ef9b0c832399bc76c24b9e1c1d