### PR TITLE
Fix MSVC compile flags for gtk module

### DIFF
--- a/modules/gtk/CMakeLists.txt
+++ b/modules/gtk/CMakeLists.txt
@@ -21,7 +21,13 @@ add_definitions(${GTK3_CFLAGS} ${GTK3_CFLAGS_OTHER})
 target_link_directories(${PROJECT_NAME} PRIVATE ${GTK3_LIBRARY_DIRS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${GTK3_LIBRARIES})
 
-target_compile_options(${PROJECT_NAME} PRIVATE
-    -Wno-strict-prototypes
-    -Wno-deprecated-declarations
-)
+if(MSVC)
+  target_compile_options(${PROJECT_NAME} PRIVATE
+      /wd4996
+  )
+else()
+  target_compile_options(${PROJECT_NAME} PRIVATE
+      -Wno-strict-prototypes
+      -Wno-deprecated-declarations
+  )
+endif()


### PR DESCRIPTION
## Summary
- guard the GTK module's GCC-specific warning suppressions so they are not passed to MSVC
- add the MSVC-specific /wd4996 option to keep deprecated warnings disabled when building on Windows

## Testing
- cmake -S . -B build-verify *(fails: FetchContent clone blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2a4c360c8323916e992cadb338a1