### PR TITLE
Limit snapshot build warning suppression to GCC

### DIFF
--- a/modules/snapshot/CMakeLists.txt
+++ b/modules/snapshot/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
     add_library(${PROJECT_NAME} MODULE ${SRCS})
 endif()
 
-if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_compile_options(${PROJECT_NAME} PRIVATE
         -Wno-clobbered
     )


### PR DESCRIPTION
## Summary
- gate the snapshot module's `-Wno-clobbered` flag to GNU compilers only so MSVC builds no longer receive an unsupported option

## Testing
- `cmake -S . -B build` *(fails: FetchContent libre download blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68cc31c05abc83238aa146c98fd7313a