### PR TITLE
Ensure MSVC compat unistd stub is created for libre build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,13 +184,12 @@ if(MSVC AND DEFINED BARESIP_MSVC_COMPAT_DIR)
 
   if(DEFINED libre_SOURCE_DIR)
     set(_libre_source_include_dir "${libre_SOURCE_DIR}/include")
-    if(EXISTS "${_libre_source_include_dir}")
-      configure_file(
-        "${BARESIP_MSVC_COMPAT_DIR}/unistd.h"
-        "${_libre_source_include_dir}/unistd.h"
-        COPYONLY
-      )
-    endif()
+    file(MAKE_DIRECTORY "${_libre_source_include_dir}")
+    configure_file(
+      "${BARESIP_MSVC_COMPAT_DIR}/unistd.h"
+      "${_libre_source_include_dir}/unistd.h"
+      COPYONLY
+    )
     unset(_libre_source_include_dir)
   endif()
 


### PR DESCRIPTION
## Summary
- always create the libre source and binary include directories before copying the MSVC compatibility unistd.h stub
- ensure the stub is available when building libre with MSVC so zlib's zconf.h can include it

## Testing
- cmake -S . -B build *(fails: libre dependency fetch blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc34c6e0a083239c1cf48ef39b3ff4