### PR TITLE
Fix Windows workflow compatibility for MSVC builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -75,7 +75,11 @@ jobs:
         shell: cmd
         run: |
           call "${{ matrix.config.environment_script }}"
+          if not exist re\include mkdir re\include
+          copy /Y include\msvc_compat\unistd.h re\include\unistd.h
           cmake -S re -B re/build -G "Ninja" -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=${{ matrix.config.disable_openssl }}
+          if not exist re\build\include mkdir re\build\include
+          copy /Y include\msvc_compat\unistd.h re\build\include\unistd.h
           cmake --build re/build -j
           mv re ../.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,14 @@ if(APPLE)
 endif()
 
 if(MSVC)
-  add_compile_options("/W3")
+  # Windows SDK headers emit numerous unknown `_warning` pragmas when
+  # building with MSVC.  Those warnings (C4068) become fatal once `/WX`
+  # is enabled in the CI configuration, so silence them explicitly while
+  # keeping the requested warning level for the project sources.
+  add_compile_options(
+    "/W3"
+    "/wd4068"
+  )
 else()
   add_compile_options(
     -Wall


### PR DESCRIPTION
## Summary
- copy the MSVC compatibility `unistd.h` header into the fetched libre repository before building on Windows
- silence MSVC's C4068 unknown pragma warnings so `/WX` no longer breaks the build when Windows headers emit `_warning`

## Testing
- cmake -S . -B build *(fails: cannot clone https://github.com/baresip/re.git from the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4a7ca1c88323a7b0f9541266b2a1