### PR TITLE
Disable pkg-config detection for GTK3 on MSVC builds

### DIFF
--- a/cmake/FindGTK3.cmake
+++ b/cmake/FindGTK3.cmake
@@ -11,8 +11,11 @@
 
 set(_GTK3_PKGCONFIG_FOUND FALSE)
 
+# pkg-config provides GCC style import libraries which are not compatible
+# with MSVC builds.  Skip the pkg-config path so that Windows/MSVC uses the
+# manual discovery logic below instead.
 find_package(PkgConfig QUIET)
-if(PkgConfig_FOUND)
+if(PkgConfig_FOUND AND NOT MSVC)
   pkg_check_modules(GTK3 QUIET gtk+-3.0)
   if(GTK3_FOUND)
     set(_GTK3_PKGCONFIG_FOUND TRUE)


### PR DESCRIPTION
## Summary
- skip pkg-config based GTK3 detection when compiling with MSVC so that Windows builds rely on the manual lookup that requires import libraries
- document why pkg-config is not used for MSVC builds in FindGTK3.cmake

## Testing
- cmake -S . -B build -G Ninja *(fails: FetchContent clone blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68cc604ae5248323baf2d162b33b1776