### PR TITLE
Fix GTK module include dirs

### DIFF
--- a/modules/gtk/CMakeLists.txt
+++ b/modules/gtk/CMakeLists.txt
@@ -18,6 +18,7 @@ else()
 endif()
 
 add_definitions(${GTK3_CFLAGS} ${GTK3_CFLAGS_OTHER})
+target_include_directories(${PROJECT_NAME} PRIVATE ${GTK3_INCLUDE_DIRS})
 target_link_directories(${PROJECT_NAME} PRIVATE ${GTK3_LIBRARY_DIRS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${GTK3_LIBRARIES})
 


### PR DESCRIPTION
## Summary
- ensure the GTK module uses GTK3-provided include directories when compiling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc77365104832392818d7b900e2dd0